### PR TITLE
Sim functions fixed & added

### DIFF
--- a/Functions_new/simulations.R
+++ b/Functions_new/simulations.R
@@ -45,9 +45,9 @@ plot_length <- function(results, cdi_name, se, bin_width = 10, pfs = 6, xfs = 14
   #
   # Parameters:
   # 1: results - simulation results (as returned by sim_se(), which is a wrapper for mirtCAT())
-  # 2: cdi_name - for the plot title: name of the CDI
-  # 3: se - for the plot title: SE threshold used as a stopping criterion in sim_se()
-  # 4: bin_width - (optional) defaults to 10 and last bin always equals to all items used while second to last always adjusts
+  # 2: cdi_name - for plot title: name of the CDI
+  # 3: se - for plot title: SE threshold used as a stopping criterion in sim_se()
+  # 4: bin_width - (optional) defaults to 10 (last bin always equals to all items used while second to last always adjusts)
   # 5: pfs - (optional) font size for percentages above bars
   # 6: xfs - (optional) font size for bin labels on X axis
   # 7: title - (optional) defaults to "cdi_name with stop criterion SE < se"
@@ -74,4 +74,11 @@ plot_length <- function(results, cdi_name, se, bin_width = 10, pfs = 6, xfs = 14
     theme_pubclean() +
     ylim(0, 100) +
     theme(text = element_text(size=16), axis.text.x = element_text(size=xfs))
+}
+
+sim_length_distro_q <- function(results, q) {
+  tests_lengths <- laply(results, function(x) length(x$items_answered))
+  threshold <- quantile(tests_lengths, 1 - q)
+  print(threshold)
+  invisible(list(distro = tests_lengths, threshold = round(threshold)))
 }

--- a/Functions_new/simulations.R
+++ b/Functions_new/simulations.R
@@ -37,21 +37,41 @@ report_sim_results <- function(sim_results, fscores, cdi_length = nrow(cdi)){
   return(paste("Mean length:", mean_length, " Median length:", median_length, " Correlation:", cor, " Mean SE:", meanSE, " Reliability:", rel, " Unused items:", unused))
 }
 
-plot_length <- function(results, cdi_name, se) {
+plot_length <- function(results, cdi_name, se, bin_width = 10, pfs = 6, xfs = 14, title = paste0(cdi_name, " with stop criterion SE < ", ceiling(se * 100) / 100)) {
+
+  ###
+  # Plots a histogram of the distribution of administration length (number of items)
+  # for given simulation results.
+  #
+  # Parameters:
+  # 1: results - simulation results (as returned by sim_se(), which is a wrapper for mirtCAT())
+  # 2: cdi_name - for the plot title: name of the CDI
+  # 3: se - for the plot title: SE threshold used as a stopping criterion in sim_se()
+  # 4: bin_width - (optional) defaults to 10 and last bin always equals to all items used while second to last always adjusts
+  # 5: pfs - (optional) font size for percentages above bars
+  # 6: xfs - (optional) font size for bin labels on X axis
+  # 7: title - (optional) defaults to "cdi_name with stop criterion SE < se"
+  ###
+
   #Prepare cuts
   tests_lengths <- laply(results, function(x) length(x$items_answered))
-  cuts <- cut(tests_lengths, breaks = c(0, 10, 15, 25, 35, 50, 75, 100, nrow(cdi)-1, nrow(cdi)),
-              labels = c("1 - 10", "11 - 15", "16 - 25", "26 - 35", "36 - 50", "51 - 75", "76 - 100",
-                         paste("101 -", nrow(cdi)-1), paste(nrow(cdi), "(all)")))
+  len <- nrow(cdi)
+  if((len-1) %% bin_width < bin_width/2) {
+    breaks <- c(seq(0, len-1-bin_width, by=bin_width), len-1, len)
+  } else {
+    breaks <- c(seq(0, len-1, by=bin_width), len-1, len)
+  }
+  labels <- c(paste(breaks+1, breaks[-1], sep = "-")[1:(length(breaks)-2)], paste(len, "(all)"))
+  cuts <- cut(tests_lengths, breaks = breaks, labels = labels)
 
   #Plot
   ggplot(data.frame(round(table(cuts) / nrow(responses) * 100, 1)), aes(x = cuts, y = Freq)) +
     xlab("Number of items administered") +
     ylab("Percent of respondents (%)") +
     geom_bar(stat = "identity") +
-    geom_text(aes(label = Freq), vjust = -0.3, size=6) +
-    labs(title = paste0(cdi_name, ": SE = ", se, " stop criterion")) +
+    geom_text(aes(label = Freq), vjust = -0.3, size=pfs) +
+    labs(title = title) +
     theme_pubclean() +
     ylim(0, 100) +
-    theme(text = element_text(size=16))
+    theme(text = element_text(size=16), axis.text.x = element_text(size=xfs))
 }


### PR DESCRIPTION
- `plot_length()` adapts to the length of scale now (plus a number of useful options: documented in the comment)
- `sim_length_distro_q()` identifies the max. number of items cutting of *q* of simulated administrations (plus returns quietly the whole vector of simulated administration lengths